### PR TITLE
Some optimizations

### DIFF
--- a/lib/Data/MessagePack/Packer.pm6
+++ b/lib/Data/MessagePack/Packer.pm6
@@ -27,49 +27,43 @@ module Data::MessagePack::Packer {
                 X::Data::MessagePack::Packer.new(reason => "Number to big to be converted").throw;
             }
             when * < -2**31 {
-                my @segments;
-                my $copy = $i;
-                for (56, 48, 40, 32, 24 , 16, 8, 0) -> $e {
-                    @segments.push( $copy div 2**$e );
-                    $copy %= 2**$e;
-                }
-                return Blob.new( 0xd3, @segments );
+                return Blob.new(0xd3, $i +> 31 +> 25 +& 0xff,  # Rakudo bug, can't shift 32 or more
+                                      $i +> 31 +> 17 +& 0xff,
+                                      $i +> 31 +> 9  +& 0xff,
+                                      $i +> 31 +> 1  +& 0xff,
+                                      $i +> 24       +& 0xff,
+                                      $i +> 16       +& 0xff,
+                                      $i +> 8        +& 0xff,
+                                      $i             +& 0xff);
             }
             when * < -2**15 {
-                my @segments;
-                my $copy = $i;
-                for (24, 16, 8, 0) -> $e {
-                    @segments.push( $copy div 2**$e );
-                    $copy %= 2**$e;
-                }
-                return Blob.new( 0xd2, @segments );
+                return Blob.new(0xd2, $i +> 24 +& 0xff,
+                                      $i +> 16 +& 0xff,
+                                      $i +> 8  +& 0xff,
+                                      $i       +& 0xff);
+
             }
-            when * < -2**7 { return Blob.new( 0xd1, $i div 256, $i % 256 )}
+            when * < -2**7 { return Blob.new( 0xd1, $i +> 8 +& 0xff, $i +& 0xff )}
             when * < -32 { return Blob.new( 0xd0, $i ) }
             when * < 0 { return Blob.new( $i +& 255 ) }
             when * < 128 { return Blob.new( $i ) }
             when * < 2**8 { return Blob.new( 0xcc, $i ) }
-            when * < 2**16 {
-                #until i find a way to _pack the value
-                return Blob.new( 0xcd, $i div 256, $i % 256 );
-            }
+            when * < 2**16 { return Blob.new(0xcd, $i +> 8 +& 0xff, $i +& 0xff); }
             when * < 2**32 {
-                my @segments;
-                my $copy = $i;
-                for (24, 16, 8, 0) -> $e {
-                    @segments.push( $copy div 2**$e );
-                    $copy %= 2**$e;
-                }
-                return Blob.new( 0xce, @segments );
+                return Blob.new(0xce, $i +> 24 +& 0xff,
+                                      $i +> 16 +& 0xff,
+                                      $i +> 8  +& 0xff,
+                                      $i       +& 0xff);
             }
             when * < 2**64 {
-                my @segments;
-                my $copy = $i;
-                for (56, 48, 40, 32, 24, 16, 8, 0) -> $e {
-                    @segments.push( $copy div 2**$e );
-                    $copy %= 2**$e;
-                }
-                return Blob.new( 0xcf, @segments );
+                return Blob.new(0xcf, $i +> 31 +> 25 +& 0xff,  # Rakudo bug, can't shift 32 or more
+                                      $i +> 31 +> 17 +& 0xff,
+                                      $i +> 31 +> 9  +& 0xff,
+                                      $i +> 31 +> 1  +& 0xff,
+                                      $i +> 24       +& 0xff,
+                                      $i +> 16       +& 0xff,
+                                      $i +> 8        +& 0xff,
+                                      $i             +& 0xff);
             }
             default {
                 X::Data::MessagePack::Packer.new(reason => "Number to big to be converted").throw;

--- a/lib/Data/MessagePack/Unpacker.pm6
+++ b/lib/Data/MessagePack/Unpacker.pm6
@@ -1,13 +1,136 @@
 use v6;
 
+my @lookup-table =
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+    0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+    0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+    0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b,
+    0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+    0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f, 0x40, 0x41,
+    0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c,
+    0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57,
+    0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60, 0x61, 0x62,
+    0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d,
+    0x6e, 0x6f, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+    0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f,
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x0) },     # 0x80
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x1) },     # 0x81
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x2) },     # 0x82
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x3) },     # 0x83
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x4) },     # 0x84
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x5) },     # 0x85
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x6) },     # 0x86
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x7) },     # 0x87
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x8) },     # 0x88
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0x9) },     # 0x89
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0xa) },     # 0x8a
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0xb) },     # 0x8b
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0xc) },     # 0x8c
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0xd) },     # 0x8d
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0xe) },     # 0x8e
+    sub ($b, $position is rw) { _unpack-map($b, $position, 0xf) },     # 0x8f
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x0) },   # 0x90
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x1) },   # 0x91
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x2) },   # 0x92
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x3) },   # 0x93
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x4) },   # 0x94
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x5) },   # 0x95
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x6) },   # 0x96
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x7) },   # 0x97
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x8) },   # 0x98
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0x9) },   # 0x99
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0xa) },   # 0x9a
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0xb) },   # 0x9b
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0xc) },   # 0x9c
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0xd) },   # 0x9d
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0xe) },   # 0x9e
+    sub ($b, $position is rw) { _unpack-array($b, $position, 0xf) },   # 0x9f
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x00) }, # 0xa0
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x01) }, # 0xa1
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x02) }, # 0xa2
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x03) }, # 0xa3
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x04) }, # 0xa4
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x05) }, # 0xa5
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x06) }, # 0xa6
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x07) }, # 0xa7
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x08) }, # 0xa8
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x09) }, # 0xa9
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x0a) }, # 0xaa
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x0b) }, # 0xab
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x0c) }, # 0xac
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x0d) }, # 0xad
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x0e) }, # 0xae
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x0f) }, # 0xaf
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x10) }, # 0xb0
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x11) }, # 0xb1
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x12) }, # 0xb2
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x13) }, # 0xb3
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x14) }, # 0xb4
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x15) }, # 0xb5
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x16) }, # 0xb6
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x17) }, # 0xb7
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x18) }, # 0xb8
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x19) }, # 0xb9
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x1a) }, # 0xba
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x1b) }, # 0xbb
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x1c) }, # 0xbc
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x1d) }, # 0xbd
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x1e) }, # 0xbe
+    sub ($b, $position is rw) { _unpack-string($b, $position, 0x1f) }, # 0xbf
+    Any,     # 0xc0
+    Failure, # 0xc1
+    False,   # 0xc2
+    True,    # 0xc3
+    sub ($b, $position is rw) { _unpack-bin($b, $position, _unpack-uint( $b, $position, 1 )) },
+    sub ($b, $position is rw) { _unpack-bin($b, $position, _unpack-uint( $b, $position, 2 )) },
+    sub ($b, $position is rw) { _unpack-bin($b, $position, _unpack-uint( $b, $position, 4 )) },
+    Failure,  # 0xc7
+    Failure,  # 0xc8
+    Failure,  # 0xc9
+    &_unpack-float,  # 0xca
+    &_unpack-double, # 0xcb
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 1) }, # 0xcc
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 2) }, # 0xcd
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 4) }, # 0xce
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 8) }, # 0xcf
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 1 ) -^ 0xff - 1 },
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 2 ) -^ 0xffff - 1 },
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 4 ) -^ 0xffffffff - 1 },
+    sub ($b, $position is rw) { _unpack-uint($b, $position, 8 ) -^ 0xffffffffffffffff - 1 },
+    Failure, # 0xd4
+    Failure, # 0xd5
+    Failure, # 0xd6
+    Failure, # 0xd7
+    Failure, # 0xd8
+    sub ($b, $position is rw) { _unpack-string($b, $position, _unpack-uint($b, $position, 1) ) },
+    sub ($b, $position is rw) { _unpack-string($b, $position, _unpack-uint($b, $position, 2) ) },
+    sub ($b, $position is rw) { _unpack-string($b, $position, _unpack-uint($b, $position, 4) ) },
+    sub ($b, $position is rw) { _unpack-array($b, $position, _unpack-uint($b, $position, 2) ) },
+    sub ($b, $position is rw) { _unpack-array($b, $position, _unpack-uint($b, $position, 4) ) },
+    sub ($b, $position is rw) { _unpack-map($b, $position, _unpack-uint($b, $position, 2) ) },
+    sub ($b, $position is rw) { _unpack-map($b, $position, _unpack-uint($b, $position, 4) ) },
+    -0x20, -0x1f, -0x1e, -0x1d, -0x1c, -0x1b, -0x1a, -0x19, -0x18,
+    -0x17, -0x16, -0x15, -0x14, -0x13, -0x12, -0x11, -0x10, -0x0f,
+    -0x0e, -0x0d, -0x0c, -0x0b, -0x0a, -0x09, -0x08, -0x07, -0x06,
+    -0x05, -0x04, -0x03, -0x02, -0x01
+;
+
+
 module Data::MessagePack::Unpacker {
 
     our sub unpack( Blob $b ) {
         my $position = 0;
-        _unpack( Buf.new( $b ), $position );
+        _unpack( $b, $position );
     }
 
-    sub _unpack-array( Buf $b, Int $position is rw, Int $elems ) {
+}
+
+    sub _unpack( Blob $b, Int $position is rw ) {
+        my $next = @lookup-table[$b[$position++]];
+        $next ~~ Callable ?? $next($b, $position) !! $next;
+    }
+
+    sub _unpack-array( Blob $b, Int $position is rw, Int $elems ) {
         my @array = ();
         for ^$elems {
             @array.push(
@@ -17,7 +140,7 @@ module Data::MessagePack::Unpacker {
         return @array;
     }
 
-    sub _unpack-map( Buf $b, Int $position is rw, Int $elems ) {
+    sub _unpack-map( Blob $b, Int $position is rw, Int $elems ) {
         my %map = ();
         for ^$elems {
             %map{ _unpack($b, $position) } = _unpack($b, $position);
@@ -25,64 +148,8 @@ module Data::MessagePack::Unpacker {
         return %map;
     }
 
-    sub _unpack( Buf $b, Int $position is rw ) {
-        given $b[$position++] {
-            when 0xc0 { Any }
-            when 0xc2 { False }
-            when 0xc3 { True }
-            #bin
-            when 0xc4 { _unpack-bin($b, $position, _unpack-uint( $b, $position, 1 )) }
-            when 0xc5 { _unpack-bin($b, $position, _unpack-uint( $b, $position, 2 )) }
-            when 0xc6 { _unpack-bin($b, $position, _unpack-uint( $b, $position, 4 )) }
-            # extension
-            when 0xc7 { ... }
-            when 0xc8 { ... }
-            when 0xc9 { ... }
-            #floats
-            when 0xca { _unpack-float($b, $position) }
-            when 0xcb { _unpack-double($b, $position) }
-            #uint
-            when 0xcc { _unpack-uint( $b, $position, 1 ) }
-            when 0xcd { _unpack-uint( $b, $position, 2 ) }
-            when 0xce { _unpack-uint( $b, $position, 4 ) }
-            when 0xcf { _unpack-uint( $b, $position, 8 ) }
-            #int
-            when 0xd0 { _unpack-uint( $b, $position, 1 ) -^ 0xff - 1 }
-            when 0xd1 { _unpack-uint( $b, $position, 2 ) -^ 0xffff - 1 }
-            when 0xd2 { _unpack-uint( $b, $position, 4 ) -^ 0xffffffff - 1 }
-            when 0xd3 { _unpack-uint( $b, $position, 8 ) -^ 0xffffffffffffffff - 1 }
-            #fixext
-            when 0xd4 { ... }
-            when 0xd5 { ... }
-            when 0xd6 { ... }
-            when 0xd7 { ... }
-            when 0xd8 { ... }
-            #strings
-            when 0xd9 { _unpack-string($b, $position, _unpack-uint( $b, $position, 1 )) }
-            when 0xda { _unpack-string($b, $position, _unpack-uint( $b, $position, 2 )) }
-            when 0xdb { _unpack-string($b, $position, _unpack-uint( $b, $position, 4 )) }
-            #array
-            when 0xdc { _unpack-array($b, $position, _unpack-uint( $b, $position, 2) ) }
-            when 0xdd { _unpack-array($b, $position, _unpack-uint( $b, $position, 4) ) }
-            #map
-            when 0xde { _unpack-map($b, $position, _unpack-uint( $b, $position, 2) ) }
-            when 0xdf { _unpack-map($b, $position, _unpack-uint( $b, $position, 4) ) }
-            #positive fixint 0xxxxxxx	0x00 - 0x7f
-            when * +& 0b10000000 == 0 { $_ }
-            #fixmap          1000xxxx	0x80 - 0x8f
-            when * +& 0b11110000 == 0b10000000 { _unpack-map($b, $position, $_ +& 0x0f ) }
-            #fixarray        1001xxxx	0x90 - 0x9f
-            when * +& 0b11110000 == 0b10010000 { _unpack-array($b, $position, $_ +& 0x0f ) }
-            #fixstr          101xxxxx	0xa0 - 0xbf
-            when * +& 0b11100000 == 0b10100000 { _unpack-string($b, $position, $_ +& 0x1f ) }
-            #negative fixint 111xxxxx	0xe0 - 0xff
-            when * +& 0b11100000 == 0b11100000 { $_ +& 0x1f -^ 0x1f - 1 }
-        }
-    }
 
-}
-
-sub _unpack-uint( Buf $b, Int $position is rw, Int $byte-count ) {
+sub _unpack-uint( Blob $b, Int $position is rw, Int $byte-count ) {
     my Int $res = 0;
     for ^$byte-count {
         $res +<= 8;
@@ -91,7 +158,7 @@ sub _unpack-uint( Buf $b, Int $position is rw, Int $byte-count ) {
     return $res;
 }
 
-sub _unpack-bin( Buf $b, Int $position is rw, Int $length ) {
+sub _unpack-bin( Blob $b, Int $position is rw, Int $length ) {
     my $blob = Blob.new( $b[$position .. ($position + $length - 1)] );
     $position += $length;
     return $blob;
@@ -99,13 +166,13 @@ sub _unpack-bin( Buf $b, Int $position is rw, Int $length ) {
 
 
 
-sub _unpack-string( Buf $b, Int $position is rw, Int $length ) {
+sub _unpack-string( Blob $b, Int $position is rw, Int $length ) {
     my $str = Blob.new( $b[$position .. ($position + $length - 1)] ).decode;
     $position += $length;
     return $str;
 }
 
-sub _unpack-float( Buf $b, Int $position is rw ) {
+sub _unpack-float( Blob $b, Int $position is rw ) {
     my $raw = 0;
     for ^4 {
         $raw +<= 8;
@@ -120,7 +187,7 @@ sub _unpack-float( Buf $b, Int $position is rw ) {
     $mantissa = 1 + ( $mantissa / 2**23 );
     return $s * $mantissa * 2**$exp;
 }
-sub _unpack-double( Buf $b, Int $position is rw ) {
+sub _unpack-double( Blob $b, Int $position is rw ) {
     my $raw = 0;
     for ^8 {
         $raw +<= 8;


### PR DESCRIPTION
Loop unrolling, bitops instead of math, and use a lookup table for the various ops instead of a given which is a series of if's.  Altogether can be ~50% faster depending on what you're doing.  I didn't touch the tests which all still succeed.
